### PR TITLE
Save as __init__.pyi if __path__ exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,7 +203,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/c++,cmake,python
 

--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -107,6 +107,8 @@ class ParserDispatchMixin(IParser):
             elif isinstance(obj, TypeVar_):
                 result.type_vars.append(obj)
             elif obj is None:
+                if name == "__path__":
+                    result.is_package = True
                 pass
             else:
                 raise AssertionError()

--- a/pybind11_stubgen/structs.py
+++ b/pybind11_stubgen/structs.py
@@ -199,3 +199,4 @@ class Module:
     imports: set[Import] = field_(default_factory=set)
     aliases: list[Alias] = field_(default_factory=list)
     type_vars: list[TypeVar_] = field_(default_factory=list)
+    is_package: bool = field_(default=False)

--- a/pybind11_stubgen/writer.py
+++ b/pybind11_stubgen/writer.py
@@ -16,7 +16,7 @@ class Writer:
     ):
         assert to.exists()
         assert to.is_dir()
-        if module.sub_modules or sub_dir is not None:
+        if module.sub_modules or module.is_package or sub_dir is not None:
             if sub_dir is None:
                 sub_dir = Path(module.name)
             module_dir = to / sub_dir


### PR DESCRIPTION
In python the existence of __path__ indicates that the module is a package.
If this variable is present the module should be saved as __init__.py even if it has no submodules.