### PR TITLE
Remove leading newlines from docstrings

### DIFF
--- a/pybind11_stubgen/printer.py
+++ b/pybind11_stubgen/printer.py
@@ -124,7 +124,7 @@ class Printer:
             '"""',
             *(
                 line.replace("\\", r"\\").replace('"""', r"\"\"\"")
-                for line in doc.splitlines()
+                for line in doc.lstrip("\n").splitlines()
             ),
             '"""',
         ]


### PR DESCRIPTION
If pybind11-stubgen is run on a normal python docstring it will convert this
```py
"""
This is a docstring.
"""
```
To this
```py
"""

This is a docstring.
"""
```

The leading newline is interpreted as part of the docstring and pybind11-stubgen will add another newline as part of its formatting.
Stripping these leading newlines should have no effect in docstrings defined using pybind11 unless the user adds a leading newline for some reason.