### PR TITLE
Fix handling of nested types

### DIFF
--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -588,7 +588,7 @@ class ExtractSignaturesFromPybind11Docstrings(IParser):
         assert isinstance(union_t, ResolvedType)
         return ResolvedType(
             name=union_t.name,
-            parameters=[self.parse_type_str(variant) for variant in variants],
+            parameters=[self.parse_annotation_str(variant) for variant in variants],
         )
 
     def parse_type_str(

--- a/tests/py-demo/bindings/src/modules/functions.cpp
+++ b/tests/py-demo/bindings/src/modules/functions.cpp
@@ -9,6 +9,9 @@
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
 
+#include <variant>
+#include <list>
+
 #include <demo/sublibA/add.h>
 
 namespace {
@@ -97,6 +100,7 @@ void bind_functions_module(py::module &&m) {
     pyFoo.def(py::init<int>());
     m.def("default_custom_arg", [](Foo &foo) {}, py::arg_v("foo", Foo(5), "Foo(5)"));
     m.def("pass_callback", [](std::function<Foo(Foo &)> &callback) { return Foo(13); });
+    m.def("nested_types", [](std::variant<std::list<Foo>, Foo> arg){ return arg; });
 
 #if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 12)
     py::options options;

--- a/tests/stubs/python-3.12/pybind11-v2.11/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.11/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -18,6 +18,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "passthrough1",
     "passthrough2",
@@ -54,6 +55,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def passthrough1[T](obj: T) -> T: ...
 @typing.overload

--- a/tests/stubs/python-3.12/pybind11-v2.12/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.12/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "passthrough1",
     "passthrough2",
@@ -56,6 +57,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def passthrough1[T](obj: T) -> T: ...
 @typing.overload

--- a/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-use-type-var/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-use-type-var/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "passthrough1",
     "passthrough2",
@@ -56,6 +57,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def passthrough1[T](obj: T) -> T: ...
 @typing.overload

--- a/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "passthrough1",
     "passthrough2",
@@ -56,6 +57,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def passthrough1[T](obj: T) -> T: ...
 @typing.overload

--- a/tests/stubs/python-3.12/pybind11-v2.9/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.9/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -17,6 +17,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "passthrough1",
     "passthrough2",
@@ -52,6 +53,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def passthrough1[T](obj: T) -> T: ...
 @typing.overload

--- a/tests/stubs/python-3.12/pybind11-v3.0/numpy-array-use-type-var/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v3.0/numpy-array-use-type-var/demo/_bindings/functions.pyi
@@ -20,6 +20,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "passthrough1",
     "passthrough2",
@@ -63,6 +64,7 @@ def mul(p: typing.SupportsFloat, q: typing.SupportsFloat) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: collections.abc.Sequence[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: collections.abc.Callable[[Foo], Foo]) -> Foo: ...
 def passthrough1[T](obj: T) -> T: ...
 @typing.overload

--- a/tests/stubs/python-3.12/pybind11-v3.0/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v3.0/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -20,6 +20,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "passthrough1",
     "passthrough2",
@@ -63,6 +64,7 @@ def mul(p: typing.SupportsFloat, q: typing.SupportsFloat) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: collections.abc.Sequence[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: collections.abc.Callable[[Foo], Foo]) -> Foo: ...
 def passthrough1[T](obj: T) -> T: ...
 @typing.overload

--- a/tests/stubs/python-3.9/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.9/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "pos_kw_only_mix",
     "pos_kw_only_variadic_mix",
@@ -53,6 +54,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def pos_kw_only_mix(i: int, /, j: int, *, k: int) -> tuple: ...
 def pos_kw_only_variadic_mix(i: int, /, j: int, *args, k: int, **kwargs) -> tuple: ...


### PR DESCRIPTION
Nested type (such as in Unions) were not being processed. This is a better implementation of #18 from https://github.com/sizmailov/pybind11-stubgen/pull/263